### PR TITLE
chore: remove ignores so npm install via git will pull in src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
-# Ignore everything by default
-# NOTE: NPM publish will never ignore package.json, package-lock.json, README, LICENSE, CHANGELOG
-# https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html
-*
 
-# Don't ignore dist folder
-!dist/**
+# Originally this repo ignored everything except the !dist folder.
+# However, this is a fork and we are not publishing an actual package.
+# The code will be installed directly in package.json like this:
+# "httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
+# Due to this, all ignores are removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "httpsnippet",
-  "version": "3.0.9",
+  "version": "3.0.9-jci1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "httpsnippet",
-      "version": "3.0.9",
+      "version": "3.0.9-jci1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.9",
+  "version": "3.0.9-jci1",
   "name": "httpsnippet",
   "description": "HTTP Request snippet generator for *most* languages",
   "author": "Kong <office@konghq.com>",


### PR DESCRIPTION
By removing the ignores, npm install like this:

```json
"httpsnippet": "git+https://github.com/jci-metasys/httpsnippet.git#v3.0.9-jci1",
```

will install ALL the src. This will allow us to run a post install script and build the code.